### PR TITLE
Make runLocally.sh pass arguments correctly and use integration test jar

### DIFF
--- a/runLocally.sh
+++ b/runLocally.sh
@@ -32,7 +32,7 @@ function abort() {
 }
 
 function standalone_jar_or_maven() {
-  local -r standalone=optaweb-vehicle-routing-standalone
+  local -r standalone=optaweb-vehicle-routing-tests
 
   # BEGIN: Distribution use case
   #
@@ -43,7 +43,7 @@ function standalone_jar_or_maven() {
   # shellcheck disable=SC2154
   if [[ ! -f pom.xml && -f ${standalone}-${project.version}.jar ]]
   then
-    readonly jar=${standalone}-${project.version}.jar
+    readonly jar=${standalone}/target/quarkus-app/quarkus-run.jar
     return 0
   fi
   # END: Distribution use case
@@ -69,7 +69,7 @@ The script will grep pom.xml for project version, which is not as reliable as us
 
   echo "Project version: ${version}"
 
-  readonly jar=${standalone}/target/${standalone}-${version}.jar
+  readonly jar=${standalone}/target/quarkus-app/quarkus-run.jar
 
   if [[ ! -f ${jar} ]]
   then
@@ -90,25 +90,25 @@ function validate() {
 
 function run_optaweb() {
   declare -a args
-  args+=("--app.demo.data-set-dir=$dataset_dir")
-  args+=("--app.persistence.h2-dir=$vrp_dir/db")
-  args+=("--app.persistence.h2-filename=${osm_file%.osm.pbf}")
-  args+=("--app.routing.engine=$routing_engine")
-  if [[ ${routing_engine} == "graphhopper" ]]
+  args+=("-Dapp.demo.data-set-dir=$dataset_dir")
+  args+=("-Dapp.persistence.h2-dir=$vrp_dir/db")
+  args+=("-Dapp.persistence.h2-filename=${osm_file%.osm.pbf}")
+  args+=("-Dapp.routing.engine=$routing_engine")
+  if [[ ${routing_engine} == "GRAPHHOPPER" ]]
   then
-    args+=("--app.routing.osm-dir=$osm_dir")
-    args+=("--app.routing.gh-dir=$gh_dir")
-    args+=("--app.routing.osm-file=$osm_file")
+    args+=("-Dapp.routing.osm-dir=$osm_dir")
+    args+=("-Dapp.routing.gh-dir=$gh_dir")
+    args+=("-Dapp.routing.osm-file=$osm_file")
   fi
   # Avoid empty country-codes - that would be an invalid argument.
   if [[ -z ${cc_list} ]]
   then
     # This is the correct way to set a property to empty value. "--property=" is an invalid syntax in Spring Boot.
-    args+=("--app.region.country-codes")
+    args+=("-Dapp.region.country-codes")
   else
-    [[ ${cc_list} != "??" ]] && args+=("--app.region.country-codes=$cc_list")
+    [[ ${cc_list} != "??" ]] && args+=("-Dapp.region.country-codes=$cc_list")
   fi
-  java -jar "$jar" "${args[@]}"
+  java "${args[@]}" -jar "$jar"
 }
 
 function download() {
@@ -423,7 +423,7 @@ readonly cache_geofabrik=${cache_dir}/geofabrik
 [[ -d ${dataset_dir} ]] || mkdir "$dataset_dir"
 [[ -d ${cache_geofabrik} ]] || mkdir -p ${cache_geofabrik}
 
-declare routing_engine="graphhopper"
+declare routing_engine="GRAPHHOPPER"
 
 # Getting started (semi-interactive) - use OSM compatible with the built-in data set, download if not present.
 if [[ $# == 0 ]]


### PR DESCRIPTION
- Quarkus use -Dproperty.name=value instead of --property.name=value
- Use integration test jar so H2 database is used and we don't need
  to set up postgres
- Change "graphhopper" to "GRAPHHOPPER" as Quarkus need exact names

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
